### PR TITLE
fix content type

### DIFF
--- a/clfaucet.py
+++ b/clfaucet.py
@@ -127,6 +127,7 @@ class GetTokenHandler(tornado.web.RequestHandler):
 
   def _write_response(self, code, msg):
     self.set_status(code)
+    self.set_header('Content-Type', 'application/json; charset=UTF-8')
     self.write(msg)
 
   def _handle(self, data):
@@ -212,6 +213,7 @@ class CreateAccountHandler(tornado.web.RequestHandler):
 
   def _write_response(self, code, msg):
     self.set_status(code)
+    self.set_header('Content-Type', 'application/json; charset=UTF-8')
     self.write(msg)
 
   def _handle(self, request):


### PR DESCRIPTION
这个修复方式不算优雅，但是用来先解决问题已经足够。
优雅的姿势请参考 [tornadoweb文档](http://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write)，在write的时候直接传入 map 结构，tornado web会自动将其content-type置为 json。你这里之所以返回的content-type是html是因为你write的时候传入的参数为`json.dump`过后的`string`类型，其实不需要进行json.dump，直接返回结构体content-type自然就是json了。因为优雅的姿势设计的代码太多，所以之后再改吧。